### PR TITLE
Modify Actions workflow to upload artifact

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,3 +52,4 @@ jobs:
         with:
           name: employee_manager_artifact
           path: build/libs/*.jar
+          retention-days: 6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,3 +43,12 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Create JAR file
+        run: ./gradlew shadowJar
+
+      - name: Upload JAR file as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: employee_manager_artifact
+          path: build/libs/*.jar


### PR DESCRIPTION
With the new steps, the workflow will now upload the generated JAR file as an artifact to make testing more convenient.