### PR TITLE
Modify find command to use prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,16 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SALARY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+
+import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
-
-import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,11 +1,16 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALARY;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -15,14 +20,17 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose attributes contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: "
+            + "[" + PREFIX_ID + "ID] "
+            + "\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_ID + "A0001 ";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.function.Predicate;
 
@@ -11,20 +12,22 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all persons in address book whose attribute contain any of the keywords
+ * specified for those attributes.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose attributes contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose attributes contain "
+            + "the keyword (case-insensitive) specified for those attributes and displays them as a list "
+            + "with index numbers.\n"
             + "Parameters: "
-            + "[" + PREFIX_ID + "ID] "
+            + "[" + PREFIX_ID + "ID] " + "or [" + PREFIX_NAME + "NAME] "
             + "\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_ID + "A0001 ";
+            + "Examples: " + "\n" + COMMAND_WORD + " " + PREFIX_ID + "A0001 "
+            + "\n" + COMMAND_WORD + " " + PREFIX_NAME + "Alex ";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,11 +1,17 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.IdContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -19,15 +25,28 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_DEPARTMENT,
+                        PREFIX_ROLE, PREFIX_SALARY, PREFIX_TAG);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_DEPARTMENT,
+                PREFIX_ROLE, PREFIX_SALARY);
+
+        if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            return new FindCommand(new IdContainsKeywordPredicate(argMultimap.getValue(PREFIX_ID).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String trimmedArgs = argMultimap.getValue(PREFIX_NAME).get().trim();
+            if (trimmedArgs.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            String[] nameKeywords = trimmedArgs.split("\\s+");
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -38,7 +38,12 @@ public class FindCommandParser implements Parser<FindCommand> {
                 PREFIX_ROLE, PREFIX_SALARY);
 
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
-            return new FindCommand(new IdContainsKeywordPredicate(argMultimap.getValue(PREFIX_ID).get()));
+            String keyword = argMultimap.getValue(PREFIX_ID).get();
+            if (keyword.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            return new FindCommand(new IdContainsKeywordPredicate(keyword));
         }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String trimmedArgs = argMultimap.getValue(PREFIX_NAME).get().trim();

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,13 +2,17 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALARY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.IdContainsKeywordPredicate;

--- a/src/main/java/seedu/address/model/person/IdContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/IdContainsKeywordPredicate.java
@@ -1,8 +1,8 @@
 package seedu.address.model.person;
 
-import seedu.address.commons.util.ToStringBuilder;
-
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Tests that a {@code Person}'s {@code Id} matches any the keyword given.

--- a/src/main/java/seedu/address/model/person/IdContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/IdContainsKeywordPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Id} matches any the keyword given.
+ */
+public class IdContainsKeywordPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public IdContainsKeywordPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        // The check is case-insensitive
+        return person.getId()
+                .value.toUpperCase()
+                .contains(keyword.toUpperCase());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof IdContainsKeywordPredicate)) {
+            return false;
+        }
+
+        IdContainsKeywordPredicate otherNameContainsKeywordsPredicate = (IdContainsKeywordPredicate) other;
+        return keyword.equals(otherNameContainsKeywordsPredicate.keyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keyword", keyword).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/IdContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/IdContainsKeywordPredicate.java
@@ -17,9 +17,10 @@ public class IdContainsKeywordPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         // The check is case-insensitive
-        return person.getId()
+        return (!this.keyword.isEmpty())
+                && (person.getId()
                 .value.toUpperCase()
-                .contains(keyword.toUpperCase());
+                .contains(keyword.toUpperCase()));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -72,7 +73,8 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME
+                        + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -26,6 +26,17 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_emptyPrefix_throwsParseException() {
+        assertParseFailure(parser,
+                " " + PREFIX_ID,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser,
+                " " + PREFIX_NAME,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_validArgs_returnsFindCommand() {
         // ID attribute - no leading and trailing whitespaces
         FindCommand expectedFindCommand =

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,6 +11,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.IdContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -17,18 +20,25 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
+        // ID attribute - no leading and trailing whitespaces
         FindCommand expectedFindCommand =
+                new FindCommand(new IdContainsKeywordPredicate("A0001"));
+        assertParseSuccess(parser, " " + PREFIX_ID + "A0001", expectedFindCommand);
+
+        // Name attribute - no leading and trailing whitespaces
+        expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/person/IdContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/IdContainsKeywordPredicateTest.java
@@ -1,0 +1,67 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class IdContainsKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstKeyword = "A0001";
+        String secondKeyword = "A0002";
+
+        IdContainsKeywordPredicate firstPredicate = new IdContainsKeywordPredicate(firstKeyword);
+        IdContainsKeywordPredicate secondPredicate = new IdContainsKeywordPredicate(secondKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        IdContainsKeywordPredicate firstPredicateCopy = new IdContainsKeywordPredicate(firstKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_idContainsKeyword_returnsTrue() {
+        IdContainsKeywordPredicate predicate = new IdContainsKeywordPredicate("A0001");
+        assertTrue(predicate.test(new PersonBuilder().withId("A0001").build()));
+
+        // Mixed-case keywords
+        predicate = new IdContainsKeywordPredicate("AaB");
+        assertTrue(predicate.test(new PersonBuilder().withId("aAB").build()));
+    }
+
+    @Test
+    public void test_idDoesNotContainKeyword_returnsFalse() {
+        // Zero keywords
+        IdContainsKeywordPredicate predicate = new IdContainsKeywordPredicate("");
+        assertFalse(predicate.test(new PersonBuilder().withId("A0001").build()));
+
+        // Non-matching keyword
+        predicate = new IdContainsKeywordPredicate("A0002");
+        assertFalse(predicate.test(new PersonBuilder().withId("A0001").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "A0001";
+        IdContainsKeywordPredicate predicate = new IdContainsKeywordPredicate(keyword);
+
+        String expected = IdContainsKeywordPredicate.class.getCanonicalName() + "{keyword=" + keyword + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
Closes #98 

Modifies the Find command to be able to search by the Name or the ID attribute.
```
find i/A0001
find n/Alex
```