### PR TITLE
Update DG - Add manual test scenarios for increment, undo, redo

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -617,6 +617,31 @@ testers are expected to do more *exploratory* testing.
       Prerequisite: Salary of at least one employee in the displayed list is below 10000. <br>
       Expected: No change in salaries of all employees. Error details shown in the status message.
 
+### Undoing a modification
+
+1. Undo the previous command that caused a modification in employee data.
+
+   1. Test case: `undo`<br>
+      Prerequisite: A command that caused a modification in employee data has been made.<br>
+      Expected: Displayed list shows employee data before the last modification was made.
+   
+   1. Test case: `undo`<br>
+      Prerequisite: All commands have been undone or no commands that made a modification to employee data has been made.<br>
+      Expected: No change in displayed list and employee data. Error details shown in the status message.
+      1. Tip: A quick way to achieve the prerequisite is to close and reopen the application.
+
+### Redoing the previous undone command
+
+1. Redo the previous undone command caused by `undo`.
+
+   1. Test case: `redo`<br>
+      Prerequisite: Undo a command successfully using `undo`.<br>
+      Expected: Displayed list shows employee data with the modification that was undone by the last `undo` command.
+   
+   1. Test case: `redo`<br>
+      Prerequisite: No commands have been undone.<br>
+      Expected: No change in displayed list and employee data. Error details shown in the status message.
+
 ### Saving data
 
 1. Dealing with missing/corrupted data files

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -605,6 +605,18 @@ testers are expected to do more *exploratory* testing.
 
 1. _{ more test cases …​ }_
 
+### Incrementing salaries of multiple employees
+
+1. Incrementing salaries of all employees in the displayed list of employees.
+
+   1. Test case: `increment 1000`<br>
+      Prerequisite: Salaries of all employees do not exceed the maximum salary after increasing by 1000. <br>
+      Expected: Salaries of all employees in the list increased by 1000.
+   
+   1. Test case: `increment -10000` <br>
+      Prerequisite: Salary of at least one employee in the displayed list is below 10000. <br>
+      Expected: No change in salaries of all employees. Error details shown in the status message.
+
 ### Saving data
 
 1. Dealing with missing/corrupted data files

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -621,9 +621,9 @@ testers are expected to do more *exploratory* testing.
 
 1. Undo the previous command that caused a modification in employee data.
 
-   1. Test case: `undo`<br>
-      Prerequisite: A command that caused a modification in employee data has been made.<br>
-      Expected: Displayed list shows employee data before the last modification was made.
+   1. Test case: `delete 1` followed by `undo`<br>
+      Prerequisite: List all persons using the `list` command. At least one person in the list.<br>
+      Expected: The list is reverted to the list of employees before `delete 1` was executed.
    
    1. Test case: `undo`<br>
       Prerequisite: All commands have been undone or no commands that made a modification to employee data has been made.<br>
@@ -634,9 +634,9 @@ testers are expected to do more *exploratory* testing.
 
 1. Redo the previous undone command caused by `undo`.
 
-   1. Test case: `redo`<br>
-      Prerequisite: Undo a command successfully using `undo`.<br>
-      Expected: Displayed list shows employee data with the modification that was undone by the last `undo` command.
+   1. Test case: `delete 1` followed by `undo` followed by `redo`<br>
+      Prerequisite: List all persons using the `list` command. At least one person in the list.<br>
+      Expected: The list is reverted to the list of employees after `delete 1` was executed.
    
    1. Test case: `redo`<br>
       Prerequisite: No commands have been undone.<br>


### PR DESCRIPTION
I wrote this section a little differently from the rest of the manual test scenarios: placed the prerequisite in the test cases itself as the prerequisites are not the same for the test cases

closes #202 